### PR TITLE
ipv4: Missing sk_nulls_node_init() in ping_unhash().

### DIFF
--- a/net/ipv4/ping.c
+++ b/net/ipv4/ping.c
@@ -153,6 +153,7 @@ void ping_unhash(struct sock *sk)
 	if (sk_hashed(sk)) {
 		write_lock_bh(&ping_table.lock);
 		hlist_nulls_del(&sk->sk_nulls_node);
+		sk_nulls_node_init(&sk->sk_nulls_node);
 		sock_put(sk);
 		isk->inet_num = 0;
 		isk->inet_sport = 0;


### PR DESCRIPTION
If we don't do that, then the poison value is left in the ->pprev
backlink.

This can cause crashes if we do a disconnect, followed by a connect().

Change-Id: I13536e10c0b67bf9830af91f7ed3c4f3653d11cb
Tested-by: Linus Torvalds <torvalds@linux-foundation.org>
Reported-by: Wen Xu <hotdog3645@gmail.com>
Signed-off-by: David S. Miller <davem@davemloft.net>
(cherry picked from commit 06ad41e88e1c000b5d7d7873914e5f353faaa264)